### PR TITLE
remove extra copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 BSD 2-Clause License
 
 Copyright (c) 2019, Cisco Systems, Inc. and/or its affiliates
-Copyright (c) 2019, Author - Dhiren Tailor - tailor.dhiren@gmail.com
 
 All rights reserved.
 


### PR DESCRIPTION
There should be only one copyright notice. You are welcome to create an AUTHORS file if you want to recognize individual authors.